### PR TITLE
[Fix] Fix invalid flag '-release' error when compiling java

### DIFF
--- a/lib/getCommandByLanguage.ts
+++ b/lib/getCommandByLanguage.ts
@@ -62,7 +62,7 @@ const compileJava = ({ filename, compileOption }: CommandParameter) => {
 
     const version = versionMap[compileOption.java];
 
-    return `javac -release ${version} -J-Xms1024m -J-Xmx1920m -J-Xss512m -encoding UTF-8 ${filename}.java`;
+    return `javac --release ${version} -J-Xms1024m -J-Xmx1920m -J-Xss512m -encoding UTF-8 ${filename}.java`;
 };
 
 const compileJavaScript = ({}: CommandParameter) => {


### PR DESCRIPTION
This PR intends to fix #1.
```-release``` seems like a possible typo of ```--release```.
After changing ```-release``` to ```--release```, I confirmed that it works in macOS Sonoma
Please kindly close this pr and issue if you consider this is not valid.